### PR TITLE
TM4J-5816: Replacing bintray with nexus

### DIFF
--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -3,9 +3,9 @@
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
         <server>
-            <id>bintray-zephyrscale-zephyrscale</id>
-            <username>${ZEPHYRSCALE_JFROG_USER}</username>
-            <password>${ZEPHYRSCALE_JFROG_API_KEY}</password>
+            <id>smartbear-nexus-zephyrscale</id>
+            <username>${NEXUS_USERNAME}</username>
+            <password>${NEXUS_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -75,26 +75,6 @@
     <profiles>
         <profile>
             <id>release</id>
-            <repositories>
-                <repository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>bintray-zephyrscale-zephyrscale</id>
-                    <name>bintray</name>
-                    <url>https://dl.bintray.com/zephyrscale/zephyrscale</url>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>bintray-zephyrscale-zephyrscale</id>
-                    <name>bintray-plugins</name>
-                    <url>https://dl.bintray.com/zephyrscale/zephyrscale</url>
-                </pluginRepository>
-            </pluginRepositories>
 
             <build>
                 <plugins>
@@ -170,9 +150,9 @@
 
     <distributionManagement>
         <repository>
-            <id>bintray-zephyrscale-zephyrscale</id>
-            <name>zephyrscale-zephyrscale</name>
-            <url>https://api.bintray.com/maven/zephyrscale/zephyrscale/zephyrscale-junit-integration/;publish=1</url>
+            <id>smartbear-nexus-zephyrscale</id>
+            <name>Public Nexus Repository</name>
+            <url>https://nexus-acadia-external.smartbear.io/repository/smartbear-public/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Changes in this PR include:

- change to `distributionManagement` in `pom`, to upload artefacts to our public nexus instead of bintray repository
- change in `settings.xml` to authenticate with nexus
- removal of bintray `repositories`, since it seems they are not needed, and Maven uses central repository for all of the needed artefacts anyway (like in this [build](https://app.circleci.com/pipelines/github/SmartBear/zephyr-scale-junit-integration/29/workflows/e3be7a9d-ff1d-4511-9885-1e21007d7ad9/jobs/31))