### PR TITLE
TM4J-5816: Deploying to ossrh

### DIFF
--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -3,9 +3,9 @@
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
         <server>
-            <id>smartbear-nexus-zephyrscale</id>
-            <username>${NEXUS_USERNAME}</username>
-            <password>${NEXUS_PASSWORD}</password>
+            <id>ossrh</id>
+            <username>${OSSRH_USERNAME}</username>
+            <password>${OSSRH_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,9 @@
 
     <distributionManagement>
         <repository>
-            <id>smartbear-nexus-zephyrscale</id>
-            <name>Public Nexus Repository</name>
-            <url>https://nexus-acadia-external.smartbear.io/repository/smartbear-public/</url>
+            <id>ossrh</id>
+            <name>Sonatype OSSRH Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://bitbucket.org/smartbeartm4j/zephyrscale-junit-integration.git</connection>
-        <developerConnection>scm:git:ssh://bitbucket.org:smartbeartm4j/zephyrscale-junit-integration.git</developerConnection>
-        <url>https://bitbucket.org/smartbeartm4j/zephyrscale-junit-integration</url>
+        <connection>scm:git:git://github.com/SmartBear/zephyr-scale-junit-integration.git</connection>
+        <developerConnection>scm:git:ssh://github.com/SmartBear/zephyr-scale-junit-integration.git</developerConnection>
+        <url>https://github.com/SmartBear/zephyr-scale-junit-integration</url>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
This should deploy our changes to `oss.sonatype.org`, from where they can be promoted to the Central repository, similarly to [this guide](https://smartbear.atlassian.net/wiki/spaces/VT/pages/3359737561/Publishing+JAVA+to+mvn+central). But in our case we'd use maven instead of Gradle. 

I've also updated our scm info that was still pointing to the old bitbucket repos