### PR TITLE
TM4J-5816: Changed the keyserver

### DIFF
--- a/gen-gpg-key.sh
+++ b/gen-gpg-key.sh
@@ -11,4 +11,4 @@ Expire-Date: 0
 Passphrase: ${GPG_PASSPHRASE}
 EOF
 
-gpg --keyserver pgp.mit.edu --send-keys $(gpg --with-colons --fingerprint | awk -F: '$1 == "fpr" {print $10;}')
+gpg --keyserver hkps://keys.openpgp.org --send-keys $(gpg --with-colons --fingerprint | awk -F: '$1 == "fpr" {print $10;}')


### PR DESCRIPTION
`pgp.mit.edu` keystore stopped working for some reason, I've changed it to `hkps://keys.openpgp.org` which I tested locally and it works