### PR TITLE
TM4J-0: Correcting old bitbucket link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JUnit methods which are not annotated with `@TestCase(name = "")` will also be a
 
 ## Usage
 
-You can have a look at this [Zephyr Scale JUnit Integration Example](https://bitbucket.org/smartbeartm4j/zephyrscale-junit-integration-example) repository.
+You can have a look at this [Zephyr Scale JUnit Integration Example](https://github.com/SmartBear/zephyr-scale-junit-integration-example) repository.
 
 You need to add the dependency to your pom file.
 


### PR DESCRIPTION
This PR fixes the old Bitbucket link to **Zephyr Scale JUnit Integration Example** and replaces it with correct link to our new GitHub repo