### PR TITLE
TM4J-7177: update jackson-databind to fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.1</version>
+            <version>2.12.7.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
A vulnerability was detected within the zephyr-scale-junit-integration project through the inclusion of the com.fasterxml.jackson.core:jackson-databind dependency.

Please update to the library starting with > {'identifier': '2.12.7.1'} version